### PR TITLE
Add missing import in shopkeepers.rb plugin

### DIFF
--- a/data/game/plugins/common/shopkeepers.rb
+++ b/data/game/plugins/common/shopkeepers.rb
@@ -1,5 +1,7 @@
 require 'java'
 
+java_import 'net.scapeemulator.game.task.DistancedAction'
+
 SHOPKEEPERS = {
   519 => 'Bob\'s Brilliant Axes',
   520 => 'Falador General Store', 521 => 'Falador General Store',

--- a/src/net/scapeemulator/game/plugin/PluginLoader.java
+++ b/src/net/scapeemulator/game/plugin/PluginLoader.java
@@ -196,6 +196,7 @@ public final class PluginLoader {
 
         /* Evaluate each of the scripts */
         for(String scriptName : data.getScripts()) {
+            logger.info("Loading: " + scriptName);
             scriptEnvironment.eval(new Script(new File(scriptDir, scriptName)));
         }
 


### PR DESCRIPTION
I was trying to run the server to test something and there was an error in the pluginloader. It wasn't immediately obvious which plugin was failing so I thought it could use a logger call to specify which plugin was failing when plugins are being loaded.
